### PR TITLE
Fix Title tag in default layout

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8">
-    <title>Bootstrap, from Twitter</title>
+    <title>Ruby for Good - Making the world gooder</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="">
     <meta name="author" content="">


### PR DESCRIPTION
Was using the default bootstrap title, now uses same as ruby for good home page.
