### PR TITLE
Add 2016 event information page.

### DIFF
--- a/2016.md
+++ b/2016.md
@@ -1,0 +1,65 @@
+---
+layout: default
+---
+
+# Ruby for Good 2016
+
+[Join us on Slack](https://rubyforgood.herokuapp.com/) before, during, and after the event for announcements and making friends.
+
+### Thursday June 16th
+
+* Arrive before 5:00 pm — most of the organizing team is planning on arriving at 10:00 am but feel free to beat us there!
+* 1:00 pm - 26 people on [FONZ](https://nationalzoo.si.edu/JoinFonz/join.cfm) tour of Smithsonian-Mason Institute (see below) — [reserve your spot](https://docs.google.com/spreadsheets/d/1gTi3wUj8MJLG637wdYBsasBrca53P7X-FFjXWw-SF2k/edit?usp=sharing).
+* 5:00 pm - Event kickoff and announcements
+* 5:30 pm - Team pitches, team assignments
+* 6:30 pm - Dinner, initial team discussion, setting up environments, cloning down repos, etc.
+* 8:30 pm? - Board games, computer games, socializing, and other random fun.
+
+### Friday June 17th
+
+* 8:00 am - Breakfast
+* 9:00 am - Work on projects
+* 10:00 am - 26 people on [FONZ](https://nationalzoo.si.edu/JoinFonz/join.cfm) tour of Smithsonian-Mason Institute (see below) — [reserve your spot](https://docs.google.com/spreadsheets/d/1gTi3wUj8MJLG637wdYBsasBrca53P7X-FFjXWw-SF2k/edit?usp=sharing).
+* 12:00 pm - Lunch
+* 1:00 pm - 26 people on [FONZ](https://nationalzoo.si.edu/JoinFonz/join.cfm) tour of Smithsonian-Mason Institute (see below) — [reserve your spot](https://docs.google.com/spreadsheets/d/1gTi3wUj8MJLG637wdYBsasBrca53P7X-FFjXWw-SF2k/edit?usp=sharing).
+* 1:00 pm - Work on projects
+* 5:00 pm - Dinner
+* 6:30pm - Werewolf, board games, socializing, fun!
+
+### Saturday June 18th
+
+* 8:00 am - Breakfast
+* 9:00 am - Work on projects
+* 12:00 pm - Lunch
+* 1:00 pm - Work on projects
+* 5:00 pm - Dinner
+* 6:30pm - Outdoorsy fun (bring a sweater, lawn chairs, and a sweet tooth).
+
+### Sunday June 19th
+
+* 8:00 am - Breakfast
+* 9:00 am - Work on projects
+* 12:00 pm - Lunch
+* 1:00 pm - Demos (if your project isn't finished, demo what you can!)
+
+## Location
+
+George Mason University’s Smithsonian-Mason School of Conservation<br>
+1500 Remount Rd<br>
+Front Royal, VA 22630
+
+The location is only accessible by car — we are helping to [coordinate carpooling](https://docs.google.com/forms/d/1aA0fJbbmxYW3lTqP6A7zLOnZbECzCd5d9f7L9ok_jLI/viewform?c=0&w=1). Please fill out the form if you need a ride or can offer a ride and Kalimar will do his best to match people up! Contact Kalimar at [kalimar@rubyforgood.org](mailto:kalimar@rubyforgood.org).
+
+If you arrive and the gate is locked, dial #90 at the phone at gate #2 for access.
+
+Once you enter through the gates, drive to the top of the hill (the Smithsonian Tower with yellow and blue sun will be on your right). Make a right after the Smithsonian tower, and parking is on the right.
+
+After arriving, head to the “Residences” building to check in.
+
+## FONZ Tours
+
+The [Friends of the National Zoo (FONZ)](https://nationalzoo.si.edu/JoinFonz/join.cfm) is giving us a personalized, not-open-to-the-public tour of the Smithsonian Conservation Biology Institute (SCBI) grounds and animal habitats so we can learn about red pandas, bison, and other friendly creatures, their homes, and the research being done on-site. We have three tours lined up as indicated above. Only 26 people are allowed for each tour and tours last between 1.5 and 2 hours. Be sure to [reserve your spot](https://docs.google.com/spreadsheets/d/1gTi3wUj8MJLG637wdYBsasBrca53P7X-FFjXWw-SF2k/edit?usp=sharing) on one of the tours.
+
+## What to Bring
+
+Bring yourself, your laptop, a power source, some clothes and your favorite board games. Maybe some sunscreen if the weather’s nice. If you anticipate skipping group meals, bring some munchies. If you’re a light sleeper, bring earplugs. All the basics are provided (linens, pillows, beds, towels, etc.). We have a fun outdoor activity planned for one evening so camping chairs, a sweater and maybe some bug spray are highly recommended.


### PR DESCRIPTION
This PR introduces the 2016 event information page, which is made up of information gleaned from the rest of the current site. 

It tackles all of [the cards we had arranged into this column](http://cl.ly/0w3e1Q1G271b/Slack%20for%20iOS%20Upload%20%281%29.jpg) except “I’m a team lead, what do I do next?” because I don’t know what to do next! 

Note: base of this PR is `more-gooder`. 
