### PR TITLE
Fix layout for 2016 page.

### DIFF
--- a/2016.md
+++ b/2016.md
@@ -1,12 +1,12 @@
 ---
-layout: default
+layout: page
 ---
 
-# Ruby for Good 2016
+### Ruby for Good 2016
 
 [Join us on Slack](https://rubyforgood.herokuapp.com/) before, during, and after the event for announcements and making friends.
 
-### Thursday June 16th
+###### Thursday June 16th
 
 * Arrive before 5:00 pm — most of the organizing team is planning on arriving at 10:00 am but feel free to beat us there!
 * 1:00 pm - 26 people on [FONZ](https://nationalzoo.si.edu/JoinFonz/join.cfm) tour of Smithsonian-Mason Institute (see below) — [reserve your spot](https://docs.google.com/spreadsheets/d/1gTi3wUj8MJLG637wdYBsasBrca53P7X-FFjXWw-SF2k/edit?usp=sharing).
@@ -15,7 +15,7 @@ layout: default
 * 6:30 pm - Dinner, initial team discussion, setting up environments, cloning down repos, etc.
 * 8:30 pm? - Board games, computer games, socializing, and other random fun.
 
-### Friday June 17th
+###### Friday June 17th
 
 * 8:00 am - Breakfast
 * 9:00 am - Work on projects
@@ -26,7 +26,7 @@ layout: default
 * 5:00 pm - Dinner
 * 6:30pm - Werewolf, board games, socializing, fun!
 
-### Saturday June 18th
+###### Saturday June 18th
 
 * 8:00 am - Breakfast
 * 9:00 am - Work on projects
@@ -35,14 +35,14 @@ layout: default
 * 5:00 pm - Dinner
 * 6:30pm - Outdoorsy fun (bring a sweater, lawn chairs, and a sweet tooth).
 
-### Sunday June 19th
+###### Sunday June 19th
 
 * 8:00 am - Breakfast
 * 9:00 am - Work on projects
 * 12:00 pm - Lunch
 * 1:00 pm - Demos (if your project isn't finished, demo what you can!)
 
-## Location
+### Location
 
 George Mason University’s Smithsonian-Mason School of Conservation<br>
 1500 Remount Rd<br>
@@ -56,10 +56,10 @@ Once you enter through the gates, drive to the top of the hill (the Smithsonian 
 
 After arriving, head to the “Residences” building to check in.
 
-## FONZ Tours
+### FONZ Tours
 
 The [Friends of the National Zoo (FONZ)](https://nationalzoo.si.edu/JoinFonz/join.cfm) is giving us a personalized, not-open-to-the-public tour of the Smithsonian Conservation Biology Institute (SCBI) grounds and animal habitats so we can learn about red pandas, bison, and other friendly creatures, their homes, and the research being done on-site. We have three tours lined up as indicated above. Only 26 people are allowed for each tour and tours last between 1.5 and 2 hours. Be sure to [reserve your spot](https://docs.google.com/spreadsheets/d/1gTi3wUj8MJLG637wdYBsasBrca53P7X-FFjXWw-SF2k/edit?usp=sharing) on one of the tours.
 
-## What to Bring
+### What to Bring
 
 Bring yourself, your laptop, a power source, some clothes and your favorite board games. Maybe some sunscreen if the weather’s nice. If you anticipate skipping group meals, bring some munchies. If you’re a light sleeper, bring earplugs. All the basics are provided (linens, pillows, beds, towels, etc.). We have a fun outdoor activity planned for one evening so camping chairs, a sweater and maybe some bug spray are highly recommended.


### PR DESCRIPTION
Looks like this missed the new layout in #54 — and I also jumped on the bandwagon of #60 and made these headers a bit smaller:

![image](https://cloud.githubusercontent.com/assets/14930/16171765/fbee83a2-3545-11e6-8df2-1e176586c2f1.png)
