### PR TITLE
Fix layout for yearbook page.

### DIFF
--- a/yearbook.md
+++ b/yearbook.md
@@ -1,5 +1,5 @@
 ---
-layout: default
+layout: page
 ---
 
 <!--


### PR DESCRIPTION
Also targeted at `start_yearbook_page`, this PR just updates the name of the layout from `default` to `page`, as changed in #54.
