### PR TITLE
Link to different sections from the menu.

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,24 +1,19 @@
 <header id="header" class="navigation-bar-header light hidden-xs">
   <div class="container">
     <nav class="navigation">
-      <div class="navigation-txt visible-xs" data-toggle="dropdown">Home</div>
+      <div class="navigation-txt visible-xs" data-toggle="dropdown">Ruby for Good</div>
       <button class="navigation-toggle visible-xs" type="button" data-toggle="dropdown">
         <span class="icon-bar"></span>
         <span class="icon-bar"></span>
         <span class="icon-bar"></span>
       </button>
       <ul class="navigation-bar navigation-bar-left">
-        <li><a href="#about">About</a></li>
-        <!--<li><a href="#stat">Number Facts</a></li>-->
-        <li><a href="#elements">Details</a></li>
-        <li><a href="#speakers">Organizers</a></li>
-        <!--<li><a href="#schedule">Schedule</a></li>-->
-        <!--<li><a href="#price">Prices</a></li>-->
-        <!--<li><a href="#elements">Shortcodes</a></li>-->
-        <li><a href="#sponsors">Sponsors</a></li>
-        <li><a href="faq">FAQ</a></li>
-        <li><a href="info.html">More Info</a></li>
-        <li><a href="coc.html">Code of Conduct</a></li>
+        <li><a href="/"><strong>Ruby for Good</strong></a></li>
+        <li><a href="/sponsors.html">Sponsoring</a></li>
+        <li><a href="/submit-project.html">Suggest a Project</a></li>
+        <li><a href="/attend.html">Attending</a></li>
+        <li><a href="/2016.html">2016 Event Information</a></li>
+        <li><a href="/coc.html">Code of Conduct</a></li>
         <!--
         <li class="featured"><a href="http://rubyforgood.simpletix.com/SimpleTixExpress/Events/EventSectionDetail.aspx?ShowId=26039&EventTimeId=58394"><i class="fa fa-heart-o fa-1x"></i>Register</a></li>
         -->


### PR DESCRIPTION
This PR changes the main menu to link to the sections we have now created, rather than sections of the homepage.
- It links to `/sponsors.html`, which doesn’t yet exist: #62.
- ~~It links to `/submit-project.html`, which doesn’t yet exist: #66.~~ (it exists now)

![image](https://cloud.githubusercontent.com/assets/14930/16172732/131b077e-355c-11e6-9a2c-57566deb4318.png)

![image](https://cloud.githubusercontent.com/assets/14930/16172733/180cb89a-355c-11e6-860f-e37327636af4.png)
