### PR TITLE
Link to Projects in main navigation.

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -10,7 +10,7 @@
       <ul class="navigation-bar navigation-bar-left">
         <li><a href="/"><strong>Ruby for Good</strong></a></li>
         <li><a href="/sponsors.html">Sponsoring</a></li>
-        <li><a href="/submit-project.html">Suggest a Project</a></li>
+        <li><a href="/yearbook.html">Projects</a></li>
         <li><a href="/attend.html">Attending</a></li>
         <li><a href="/2016.html">2016 Event Information</a></li>
         <li><a href="/coc.html">Code of Conduct</a></li>

--- a/attend.md
+++ b/attend.md
@@ -31,6 +31,8 @@ Here is what actual attendees have written about the event:
 
 During registration we'll ask if you'd like to lead a team - say yes! We'll be in touch in mid-to-late April with potential projects. We'll brief you on expectations and put you in touch with your non-profit so you can work with them in advance of the event to set up project requirements, milestones and initial set up so you can hit the ground running with your team at Ruby for Good. Setup includes creating a github repo under the Ruby for Good github, filing issues and making some technology suggestions. For an in-depth look at what it's like to lead a team, check out Brandon Rice's [blog](http://www.blrice.net/blog/2015/08/10/leading-a-team-at-ruby-for-good/). If you're not sure and want to talk about it with an organizer? Drop us a [note](mailto:info@rubyforgood.org).
 
+Also — if you have a project in mind that you’d like to lead, [suggest a project](/submit-project.html) to work on!
+
 ### Purchasing a tickets
 
 Please check back here in Spring 2017!!!

--- a/yearbook.md
+++ b/yearbook.md
@@ -2,6 +2,10 @@
 layout: page
 ---
 
+<div class="btn-wrapper pull-right">
+<a href="/submit-project.html" class="btn btn-sm btn-primary">Suggest a Project</a>
+</div>
+
 <!--
   Template for Project
     ## Title of the Project


### PR DESCRIPTION
This PR replaces “Suggest a Project” in the main navigation with “Projects”, which sends you to our yearbook of projects. 

It also adds a link to “Suggest a Project” to that page: 

![image](https://cloud.githubusercontent.com/assets/14930/16173340/8d99e212-356c-11e6-8832-fbb904155ea1.png)

Thoughts? 
