### PR TITLE
Tweak styles on yearbook page.

### DIFF
--- a/_includes/github-block.html
+++ b/_includes/github-block.html
@@ -1,0 +1,12 @@
+<div class="github-block" markdown="1">
+<a href="{{ include.href }}" class="btn btn-xs btn-primary pull-left" target="_blank">View Project on GitHub</a>
+
+{% assign team = include.team | split:"|" %}
+
+{: .github-avatars .pull-left}
+{% for member in team %}
+- {% include github-avatar.html username=member %}
+{% endfor %}
+
+</div>
+<div class="clearfix"></div>

--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -48,14 +48,23 @@ color: #57c2be;
   margin-bottom: 7px;
 }
 
+.github-block a.btn {
+  margin: 0 20px 20px 0;
+}
+
 .github-avatars {
   padding: 0;
+  margin: 0 0 20px 0;
   list-style-type: none;
 }
 
+.github-avatars p {
+  margin: 0;
+}
+
 .github-avatars img {
-  width: 50px;
-  height: 50px;
+  width: 55px;
+  height: 55px;
   border-radius: 50%;
   border: 1px rgba(0,0,0,0.1) solid;
 }
@@ -75,5 +84,9 @@ color: #57c2be;
   top: 0;
   right: -25px;
   font-size: 20px;
-  line-height: 50px;
+  line-height: 55px;
+}
+
+.github-avatars li:only-of-type:after {
+  display: none;
 }

--- a/yearbook.md
+++ b/yearbook.md
@@ -29,95 +29,66 @@ Learn more about the projects from past years and take a trip down memory lane a
 
 ##### Portland Diaper Bank
 
-There are 150,000 children living in poverty in Oregon whose parents often have to make the difficult choice of choosing between feeding their children and putting diapers on them. The great people at the Portland Diaper Bank are helping and need our help to do the great work that they do! They need a database, integrated bar code scanner (awesome!) and some other stuff to make their lives easier and give them more time to do the good work that they do.
+There are 150,000 children living in poverty in Oregon whose parents often have to make the difficult choice of choosing between feeding their children and putting diapers on them. The great people at the Portland Diaper Bank are helping and need our help to do the great work that they do! They need a database, integrated bar code scanner (awesome!) and some other stuff to make their lives easier and give them more time to do the good work that they do. <a href="http://www.pdxdiaperbank.org/" target="_blank">More about the Portland Diaper Bank</a>.
 
-[https://github.com/rubyforgood/pdx_diaper](https://github.com/rubyforgood/pdx_diaper)
-
-{: .github-avatars}
-- {% include github-avatar.html username="armahillo" %}
-- {% include github-avatar.html username="D-matz" %}
-- {% include github-avatar.html username="cattywampus" %}
-- {% include github-avatar.html username="tmobaird" %}
-- {% include github-avatar.html username="katiesteiner" %}
+{% include github-block.html
+  href="https://github.com/rubyforgood/pdx_diaper"
+  team="armahillo|D-matz|cattywampus|tmobaird|katiesteiner"
+%}
 
 ##### Smithsonian Studying the Scimitar Oryx
 
 Let's be honest, we all want to do great things. What is better than being part of a group that is helping to bring a species that is extinct in the wild back? There are captive populations of the oryx on ranches in Texas that researchers need some help with. They need a centralized database to keep track of the oryx, things like numbers, breeding history (can't let them get inbred), and so on. Once a stable gene pool and other information can be established, researchers are hoping to re-introduce them into the wild!
 
-[https://github.com/rubyforgood/scimitar_oryx](https://github.com/rubyforgood/scimitar_oryx)
-
-{: .github-avatars}
-- {% include github-avatar.html username="pachacamac" %}
-- {% include github-avatar.html username="cmar" %}
-- {% include github-avatar.html username="nht007" %}
-- {% include github-avatar.html username="duaimei" %}
-- {% include github-avatar.html username="SuperJones" %}
-- {% include github-avatar.html username="jcavena" %}
-- {% include github-avatar.html username="rpchurchill" %}
-- {% include github-avatar.html username="mkmckenzie" %}
+{% include github-block.html
+  href="https://github.com/rubyforgood/scimitar_oryx"
+  team="pachacamac|cmar|nht007|duaimei|SuperJones|jcavena|rpchurchill|mkmckenzie"
+%}
 
 ##### Smithsonian Logging the Loggerhead
 
 There is only one Shrike native to North America and it is a surprisingly important part of the ecosystem. While they were once extremely common throughout the eastern US and Canada, no other bird species has seen their populations reduced as much since the 1960s. The Conservation Centers for Species Survival needs an application to serve as a central repository for researchers in Canada, the US and Mexico to log their research. How amazing would it be to be part of research that may prevent this amazing animal from going extinct?
 
-[https://github.com/rubyforgood/loggerhead_shrike/graphs/contributors](https://github.com/rubyforgood/loggerhead_shrike/graphs/contributors)
-
-{: .github-avatars}
-- {% include github-avatar.html username="jjlangholtz" %}
-- {% include github-avatar.html username="michaelbyrd" %}
-- {% include github-avatar.html username="holytoastr" %}
-- {% include github-avatar.html username="marshmalien" %}
-- {% include github-avatar.html username="jkeam" %}
-
+{% include github-block.html
+  href="https://github.com/rubyforgood/loggerhead_shrike"
+  team="jjlangholtz|michaelbyrd|holytoastr|marshmalien|jkeam"
+%}
 
 ##### Smithsonian Red Pandas
 
 The red panda researchers are currently using a mish-mash of methods for recording notes and pictures on the state of the red pandas. They need something centralized and accessible by other people. They'd also ideally like the application to work well on tablets since when they are out with the red pandas they use tablets to record their notes.
 
-[https://github.com/rubyforgood/panda_app](https://github.com/rubyforgood/panda_app)
-
-{: .github-avatars}
-- {% include github-avatar.html username="rmalecky" %}
-- {% include github-avatar.html username="bhaibel" %}
-- {% include github-avatar.html username="tpinecone" %}
-- {% include github-avatar.html username="jgaskins" %}
-- {% include github-avatar.html username="nathanielksmith" %}
+{% include github-block.html
+  href="https://github.com/rubyforgood/panda_app"
+  team="rmalecky|bhaibel|tpinecone|jgaskins|nathanielksmith"
+%}
 
 ##### Working Landscapes
 
 The amazing people at the Virginia Working Landscapes have done all the heavy lifting and now just need somewhere to house their information. Partner land-owners throughout the state in numerous watershed zones are doing the hard work of gathering and recording wetland data. This data is invaluable for state conservation efforts but their current process of having to email that data in is slowing down their process. They need an application for these participants to log and record their findings, ideally something responsive so they can do it from their phones/tablets while gathering the data.
 
-[https://github.com/rubyforgood/working_landscapes](https://github.com/rubyforgood/working_landscapes)
-
-{: .github-avatars}
-- {% include github-avatar.html username="h-m-m" %}
-- {% include github-avatar.html username="maxtedford" %}
-- {% include github-avatar.html username="exbinary" %}
+{% include github-block.html
+  href="https://github.com/rubyforgood/working_landscapes"
+  team="h-m-m|maxtedford|exbinary"
+%}
 
 ##### NOLA Habitat Humanity
 
 As software developers we have it pretty good and and housing isn't a concern for us. Unfortunately, not everyone is as lucky, especially the people of New Orleans. Despite hurricane Katrina happening about a decade ago, there are still a lot of displaced people in temporary residences who need somewhere to call home. The amazing people at habitat for humanity are trying to fix this with their work in New Orleans 9th ward (one of the hardest hit areas by Katrina) and with a recent grant they received their work is only going to move quicker. The problem is, one of the requirements of the grant is a stricter recording and reporting process of their 300 or so daily volunteers which is where we come in! Let's help them with the great work they are doing by making this process faster so they have more time to rebuilding people's lives.
 
-[https://github.com/rubyforgood/habitat_humanity](https://github.com/rubyforgood/habitat_humanity)
-
-{: .github-avatars}
-- {% include github-avatar.html username="robbkidd" %}
-- {% include github-avatar.html username="pat" %}
-- {% include github-avatar.html username="scooter-dangle" %}
-- {% include github-avatar.html username="bjmllr" %}
-- {% include github-avatar.html username="Brantron" %}
+{% include github-block.html
+  href="https://github.com/rubyforgood/habitat_humanity"
+  team="robbkidd|pat|scooter-dangle|bjmllr|Brantron"
+%}
 
 ##### Share Christmas
 
 It is an unfortunate reality that not every child has presents under their Christmas tree. The amazing people at the Durham Volunteer Center have a program, Share your Christmas, that matches needy children up with people able to ensure they have something special under their tree. They need a new app to facilitate their process of matching donors and receivers. Ideally they would also like to have it generic enough to also work for thanksgiving (turkeys) and the start of the school year (backpacks full of school supplies for kids.) Even though their current process is extremely terrible, other cities have expressed interest in this so this group will potentially be helping kids from all over the country!
 
-{: .github-avatars}
-- {% include github-avatar.html username="craig-riecke" %}
-- {% include github-avatar.html username="AEgan" %}
-- {% include github-avatar.html username="nolds9" %}
-- {% include github-avatar.html username="ajohnson052" %}
-- {% include github-avatar.html username="jaydorsey" %}
-
+{% include github-block.html
+  href="https://github.com/rubyforgood/share_christmas"
+  team="craig-riecke|AEgan|nolds9|ajohnson052|jaydorsey"
+%}
 
 ##### Manjia
 
@@ -131,40 +102,19 @@ In 2015, Ruby for Good was held at the Fairfax Campus of George Mason University
 
 ##### Humane Society of Fairfax County
 
-[https://github.com/rubyforgood/hsfc](https://github.com/rubyforgood/hsfc)
-
-{: .github-avatars}
-- {% include github-avatar.html username="adamlwalker" %}
-- {% include github-avatar.html username="maebeale" %}
-- {% include github-avatar.html username="dgarnder" %}
-- {% include github-avatar.html username="jjlangholtz" %}
-- {% include github-avatar.html username="valeriecodes" %}
-- {% include github-avatar.html username="ldewald" %}
-- {% include github-avatar.html username="madtypist" %}
-- {% include github-avatar.html username="michaelbyrd" %}
-- {% include github-avatar.html username="Ameria" %}
-- {% include github-avatar.html username="htakeguchi" %}
-- {% include github-avatar.html username="pamtaro" %}
-- {% include github-avatar.html username="edwardpark" %}
+{% include github-block.html
+  href="https://github.com/rubyforgood/hsfc"
+  team="adamlwalker|maebeale|dgarnder|jjlangholtz|valeriecodes|ldewald|madtypist|michaelbyrd|Ameria|htakeguchi|pamtaro|edwardpark"
+%}
 
 ##### The Purple Door
 
 Purple Door Coffee is a specialty espresso bar and coffee shop in Denver, Colorado that employs teens and young adults who have been homeless and want to leave homelessness behind. Their mission is to reclaim and sustain the lives of homeless youth and young adults through supportive and meaningful employment.
 
-[https://github.com/rubyforgood/purple_door-1](https://github.com/rubyforgood/purple_door-1)
-
-{: .github-avatars}
-- {% include github-avatar.html username="saturnflyer" %}
-- {% include github-avatar.html username="elight" %}
-- {% include github-avatar.html username="crrdev01" %}
-- {% include github-avatar.html username="jcavena" %}
-- {% include github-avatar.html username="mallorybucell" %}
-- {% include github-avatar.html username="jgujgu" %}
-- {% include github-avatar.html username="CraigJZ" %}
-- {% include github-avatar.html username="jayroh" %}
-- {% include github-avatar.html username="gxespino" %}
-- {% include github-avatar.html username="mlpinit" %}
-- {% include github-avatar.html username="GeekOnCoffee" %}
+{% include github-block.html
+  href="https://github.com/rubyforgood/purple_door-1"
+  team="saturnflyer|elight|crrdev01|jcavena|mallorybucell|jgujgu|CraigJZ|jayroh|gxespino|mlpinit|GeekOnCoffee"
+%}
 
 ##### Growhaus
 
@@ -172,41 +122,28 @@ A statistics recording and tracking application made for the folks at The Growha
 
 The GrowHaus is a nonprofit indoor farm in Denver's Elyria-Swansea neighborhood. Our vision is to catalyze a neighborhood-based food system in our community that is healthy, equitable, and resident-driven.
 
-{: .github-avatars}
-- {% include github-avatar.html username="nevern02" %}
-- {% include github-avatar.html username="indiesquidge" %}
-- {% include github-avatar.html username="adunkman" %}
-- {% include github-avatar.html username="bengm" %}
-- {% include github-avatar.html username="nonegiven444" %}
-- {% include github-avatar.html username="waffle-iron" %}
-- {% include github-avatar.html username="fearthegoat" %}
+{% include github-block.html
+  href="https://github.com/rubyforgood/growhaus_stats"
+  team="nevern02|indiesquidge|adunkman|bengm|nonegiven444|waffle-iron|fearthegoat"
+%}
 
 ##### AllIncomeFoods
 
-An app that lists places that accept food stamps
+An app that lists places that accept food stamps.
 
-[https://github.com/rubyforgood/AllIncomeFoods](https://github.com/rubyforgood/AllIncomeFoods)
-
-{: .github-avatars}
-- {% include github-avatar.html username="shrtlist" %}
-- {% include github-avatar.html username="jwieringa" %}
-- {% include github-avatar.html username="jerseycoder" %}
-- {% include github-avatar.html username="abannert" %}
-- {% include github-avatar.html username="ysiadf" %}
-- {% include github-avatar.html username="mabundo" %}
-- {% include github-avatar.html username="onezerojeremy" %}
-- {% include github-avatar.html username="zph" %}
-- {% include github-avatar.html username="kwals" %}
-- {% include github-avatar.html username="rmalecky" %}
-- {% include github-avatar.html username="tommarkallen" %}
-- {% include github-avatar.html username="davidx" %}
+{% include github-block.html
+  href="https://github.com/rubyforgood/AllIncomeFoods"
+  team="shrtlist|jwieringa|jerseycoder|abannert|ysiadf|mabundo|onezerojeremy|zph|kwals|rmalecky|tommarkallen|davix"
+%}
 
 ##### RSpec
 
-Contributing to the RSpec testing framework
+Contributing to the RSpec testing framework.
 
-{: .github-avatars}
-- {% include github-avatar.html username="cupakromer" %}
+{% include github-block.html
+  href="https://github.com/rspec/rspec"
+  team="cupakromer"
+%}
 
 ---
 
@@ -224,18 +161,15 @@ Kutoa is an innovative giving movement that is uniting people around the world t
 
 Pathway Homes is a charitable organization providing non-time-limited housing and supportive services to adults with serious mental illness and other co-occurring disabilities in Northern Virginia. Founded in 1980, Pathways currently serves more than 400 adults with serious mental illness in community-based homes in Northern Virginia.
 
-[https://github.com/rubyforgood/pathway-homes](https://github.com/rubyforgood/pathway-homes)
+{% include github-block.html
+  href="https://github.com/rubyforgood/pathway-homes"
+%}
 
 ##### Trail Reporter
 
 App for crowdsourcing hiking trail hazards and conditions.
 
-[https://github.com/rubyforgood/trail_reporter](https://github.com/rubyforgood/trail_reporter)
-
-{: .github-avatars}
-- {% include github-avatar.html username="syoder" %}
-- {% include github-avatar.html username="alloy-d" %}
-- {% include github-avatar.html username="briandamaged" %}
-- {% include github-avatar.html username="maryhipp" %}
-- {% include github-avatar.html username="michaelbyrd" %}
-- {% include github-avatar.html username="joellastraley" %}
+{% include github-block.html
+  href="https://github.com/rubyforgood/trail_reporter"
+  team="syoder|alloy-d|briandamaged|maryhipp|michaelbyrd|joellastraley"
+%}


### PR DESCRIPTION
This PR tweaks some styles on the yearbook page — it makes a “View Project on GitHub” link that floats to the left of the list of contributors. 

It also encapsulates more of the boilerplate junk into another `includes`, making the code for each project simpler.

![image](https://cloud.githubusercontent.com/assets/14930/16173677/256f17f6-3577-11e6-9aea-913db04205b4.png)
