### PR TITLE
Reduce the minimum preloader time

### DIFF
--- a/assets/js/scripts.js
+++ b/assets/js/scripts.js
@@ -25,8 +25,8 @@
 
   $(function() {
     //Preloader
-    app.el['loader'].delay(700).fadeOut();
-    app.el['mask'].delay(1200).fadeOut("slow");
+    app.el['loader'].delay(5).fadeOut();
+    app.el['mask'].delay(100).fadeOut("slow");
 
     // Resized based on screen size
     app.el['window'].resize(function() {


### PR DESCRIPTION
Still shows the loader, but is is much less intrusive. 

I did consider using this gif, but it was so awesome it made the rest of the site look boring and drab:

![kalimar-messed-up](https://cloud.githubusercontent.com/assets/16963/16177958/7ab2b3fc-3609-11e6-82f3-8288b595f915.gif)
