### PR TITLE
Actually center the loading image.

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -2,6 +2,14 @@
   color: rgba(0,0,0,0.1);
 }
 
+#loader {
+  width: 50px;
+  height: 50px;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+}
+
 #schedule .panel .panel-title h4 {
 font-size: 27px;
 display: block;


### PR DESCRIPTION
The style for the loading indicator assumed that the gif was 12px by 12px, but the actual image is 50px by 50px. This caused the image to appear off-center.
