### PR TITLE
Tweak hero spacing, remove link to booster.

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -6,6 +6,19 @@
   padding-top: 50px;
 }
 
+#hero .hero-content {
+  top: 50%;
+  margin-top: 0;
+  transform: translateY(-50%);
+}
+
+#hero .hero-bottom {
+  position: absolute;
+  bottom: 75px;
+  left: 50%;
+  transform: translateX(-50%);
+}
+
 .hero-big-em {
   color: rgba(0,0,0,0.1);
 }

--- a/index.html
+++ b/index.html
@@ -4,36 +4,31 @@ layout: base
 <section id="hero" class="light color">
   <div class="overlay color"></div>
   <div class="container">
-    <div class="home-bg">
-      <nav class="navigation navigation-social">
-        <ul class="navigation-bar">
-          <li><a href="https://twitter.com/rubyforgood"><span class="fa fa-twitter"></span></a>
-          <li><a href="http://github.com/rubyforgood"><span class="fa fa-github"></span></a>
-          <li><a href="http://www.meetup.com/Arlington-Ruby/"><span class="fa fa-smile-o"></span></a>
-           <li><a href="https://t.co/kUtI3lnpW1"><span class="fa fa-slack"></span></a>
-        </ul>
-      </nav>
-      <div class="hero-content text-center ">
-        <div class="hero-small">
-          <hr /><span>June 16th - June 19th, 2016</span><hr />
-        </div>
-        <div class="hero-big">RUBY<wbr><span class="hero-big-em">FOR</span><wbr>GOOD</div>
-        <div class="hero-normal">
-          Dedicated to making the world <strong>gooder</strong>
-        </div>
-        <!--
-        <a href="http://rubyforgood.simpletix.com/SimpleTixExpress/Events/EventSectionDetail.aspx?ShowId=26039&EventTimeId=58394" class="btn btn-lg btn-3d"><i class="fa fa-play-circle fa-2x"></i> <span>Sign Up</span></a>
-        -->
-        </br>
-        </br>
-
-        <div class="sponsor-link">
-          <a href="http://booster.com/rubyforgood2016" class="sponsor-link-text">Buy a T-Shirt and Support Ruby For Good</a>
-        </div>
-        <!-- I tried to put balloon hearts here, but couldnt get the outline to appear white, so settled for a font-awesome heart... :( -->
-        <img src="assets/img/red-panda.png" style="width:100px" />
-
+    <nav class="navigation navigation-social">
+      <ul class="navigation-bar">
+        <li><a href="https://twitter.com/rubyforgood"><span class="fa fa-twitter"></span></a></li>
+        <li><a href="http://github.com/rubyforgood"><span class="fa fa-github"></span></a></li>
+        <li><a href="http://www.meetup.com/Arlington-Ruby/"><span class="fa fa-smile-o"></span></a></li>
+        <li><a href="https://t.co/kUtI3lnpW1"><span class="fa fa-slack"></span></a></li>
+      </ul>
+    </nav>
+    <div class="hero-content text-center">
+      <div class="hero-small">
+        <hr /><span>June 16th - June 19th, 2016</span><hr />
       </div>
+      <div class="hero-big">RUBY<wbr><span class="hero-big-em">FOR</span><wbr>GOOD</div>
+      <div class="hero-normal">
+        Dedicated to making the world <strong>gooder</strong>
+      </div>
+    </div>
+    <div class="hero-bottom center">
+
+      <!--
+      <a href="http://rubyforgood.simpletix.com/SimpleTixExpress/Events/EventSectionDetail.aspx?ShowId=26039&EventTimeId=58394" class="btn btn-lg btn-3d"><i class="fa fa-play-circle fa-2x"></i> <span>Sign Up</span></a>
+      -->
+
+      <img src="assets/img/red-panda.png" style="width:100px" />
+
     </div>
   </div>
 </section>


### PR DESCRIPTION
This removes the link to the t-shirt booster campaign (it’s done!) and fixes some spacing issues.

Before: 

![snip20160619_93](https://cloud.githubusercontent.com/assets/14930/16178126/42a5f47e-360e-11e6-9972-970cfd9144d3.png)

After: 

![snip20160619_91](https://cloud.githubusercontent.com/assets/14930/16178127/479fd1ac-360e-11e6-8fd8-f0900d88f835.png)

After with the signup link visible instead of the pandaaaaa:

![snip20160619_90](https://cloud.githubusercontent.com/assets/14930/16178130/54a2e0d8-360e-11e6-9623-5cdc2e9d7b87.png)
