### PR TITLE
Fix submenu for mobile

### DIFF
--- a/assets/css/style-green.css
+++ b/assets/css/style-green.css
@@ -758,6 +758,13 @@ label.error { display: block; }
   #mobileheader .open .navigation-bar:last-child { border-top:none; padding-top: 10px; padding-bottom: 30px; }
   #mobileheader .navigation-bar li { padding-top: 2px; padding-bottom: 2px; display: block; text-align: center;}
 
+  #mobileheader li.dropdown.open ul.dropdown-menu {
+    position: static;
+    width: 100%;
+    margin: -2px 0 12px;
+    padding: 0;
+  }
+
   #hero { padding-top: 2%; }
   .navigation-bar > li.featured a { margin-left: 0 }
   .nav-tabs-simple .nav-tabs li a { font-size: 20px; padding: 0; }

--- a/assets/js/scripts.js
+++ b/assets/js/scripts.js
@@ -1,7 +1,7 @@
 (function(){
 
   // Init global DOM elements, functions and arrays
-  window.app 			                   = {el : {}, fn : {}};
+  window.app                         = {el : {}, fn : {}};
   app.el['window']                   = $(window);
   app.el['document']                 = $(document);
   app.el['back-to-top']              = $('.back-to-top');
@@ -16,7 +16,7 @@
     else if(width < 768) size = "Mobile landscape";
     else if(width < 960) size = "Tablet";
     else size = "Desktop";
-    if (width < 768){$('.animated').removeClass('animated').removeClass('hiding');}
+    if (width < 768) { $('.animated').removeClass('animated').removeClass('hiding'); }
   };
 
 
@@ -46,8 +46,17 @@
 
     $('#mobileheader').html($('#header').html());
 
+    // fix toggling dropdown inside dropdown
+    // when click on dropdown link inside mobile menu, bootstrap will toggle both, submenu and parent menu
+    // this fix will toggle only submenu
+    $('#mobileheader li.dropdown [data-toggle="dropdown"]').on('click', function (e) {
+      e.stopPropagation();
+      e.preventDefault();
+      $(this).closest('li').toggleClass('open');
+    });
+
     function heroInit() {
-      var hero        = jQuery('#hero'),
+      var hero      = jQuery('#hero'),
         winHeight   = jQuery(window).height(),
         heroHeight  = winHeight;
 


### PR DESCRIPTION
Currently if we open rubyforgood.org on mobile, open menu (burger icon on top left) and click "Attend" or "Get Involved", all menu will just disappear.

It happen because whole mobile menu is using `data-toggle="dropdown"` (feature of bootstrap) and submenus also use `data-toggle="dropdown"`. When click on submenu, bootstrap will toggle both, submenu and whole mobile menu.

This PR just override `click` event on submenu link.

<img width="430" alt="screen shot 2017-06-01 at 14 57 43" src="https://cloud.githubusercontent.com/assets/26019/26668186/2579bb72-46db-11e7-8939-b974ef443a33.png">

![img_2552](https://cloud.githubusercontent.com/assets/26019/26668289/a39cbe46-46db-11e7-8993-31fa93803c0f.PNG)
