### PR TITLE
Fix links in mobile submenu

### DIFF
--- a/assets/css/style-green.css
+++ b/assets/css/style-green.css
@@ -763,6 +763,7 @@ label.error { display: block; }
     width: 100%;
     margin: -2px 0 12px;
     padding: 0;
+    float: none;
   }
 
   #hero { padding-top: 2%; }


### PR DESCRIPTION
Bug introduced by https://github.com/rubyforgood/rubyforgood.org/pull/137

Links in submenu on mobile not working