### PR TITLE
Fix navigation visual issue

### DIFF
--- a/assets/css/style-2018.css
+++ b/assets/css/style-2018.css
@@ -156,7 +156,7 @@ hr.white { border-color: #F3AE9B; }
 .navigation-bar > li.featured {opacity:0;  -webkit-transition: all .5s linear;-moz-transition: all .5s linear; transition: all .5s linear;}
 .sticky .navigation-bar > li.featured {opacity:1;}
 
-.navigation-bar > li.featured {padding-bottom: 22px; padding-top: 22px; margin-right: 25px; float: right; }
+.navigation-bar > li.featured {padding-bottom: 22px; padding-top: 22px; float: right; }
 .navigation-bar > li.featured i{ padding-right: 10px;}
 
 .navigation-bar > li.featured a {


### PR DESCRIPTION
Moves featured navigation item to the same line as the rest of the
navigation. This also makes the content below the navigation appear
aligned while scrolling on the landing page.

### Before (see nav height and content alignment below it)
<img width="1672" alt="before 1" src="https://user-images.githubusercontent.com/5741299/84614939-8e5c5f80-ae95-11ea-97d4-99227e2d0bd7.png">
See height of nav after scrolling down
<img width="1420" alt="before 2" src="https://user-images.githubusercontent.com/5741299/84614952-94ead700-ae95-11ea-8c66-ef4dc1b5c0c6.png">

### After (see nav height and content alignment below it)
<img width="1512" alt="after 1" src="https://user-images.githubusercontent.com/5741299/84614959-9916f480-ae95-11ea-82db-c92855f83528.png">
See height of nav after scrolling down
<img width="1345" alt="after 2" src="https://user-images.githubusercontent.com/5741299/84614960-9b794e80-ae95-11ea-94b4-185018de1440.png">
